### PR TITLE
feat: Add more robustness tests for the transformer

### DIFF
--- a/tests/unit/test_transformer_more_robustness.py
+++ b/tests/unit/test_transformer_more_robustness.py
@@ -1,0 +1,54 @@
+import pytest
+from load_clinicaltrialsgov.transformer.transformer import Transformer
+from load_clinicaltrialsgov.models.api_models import Study
+
+
+def test_transform_study_with_empty_input():
+    study = Study.model_validate({
+        "protocolSection": {
+            "identificationModule": {"nctId": "NCT00000000"},
+            "statusModule": {"overallStatus": "UNKNOWN"},
+        },
+        "derivedSection": {},
+        "hasResults": False,
+    })
+    transformer = Transformer()
+    transformer.transform_study(study, {})
+    dataframes = transformer.get_dataframes()
+    assert dataframes is not None
+
+
+def test_transform_study_with_missing_required_fields():
+    mock_study_data = {
+        "protocolSection": {
+            "statusModule": {"overallStatus": "COMPLETED"}
+        },
+        "derivedSection": {},
+        "hasResults": False,
+    }
+    with pytest.raises(ValueError):
+        Study.model_validate(mock_study_data)
+
+
+def test_transform_study_with_large_strings():
+    large_string = "a" * 10000
+    mock_study_data = {
+        "protocolSection": {
+            "identificationModule": {
+                "nctId": "NCT12345",
+                "briefTitle": large_string,
+                "officialTitle": large_string,
+            },
+            "statusModule": {"overallStatus": "COMPLETED"},
+        },
+        "derivedSection": {},
+        "hasResults": False,
+    }
+    study = Study.model_validate(mock_study_data)
+    transformer = Transformer()
+    transformer.transform_study(study, mock_study_data)
+    dataframes = transformer.get_dataframes()
+
+    studies_df = dataframes["studies"]
+    assert studies_df.iloc[0]["brief_title"] == large_string
+    assert studies_df.iloc[0]["official_title"] == large_string


### PR DESCRIPTION
This commit adds a new test file, `test_transformer_more_robustness.py`, with additional tests for the `Transformer` class.

The new tests cover the following scenarios:
- Handling of empty and minimal study objects.
- Verification that Pydantic validation catches missing required fields.
- Handling of large string values in titles to prevent truncation or performance issues.