### PR TITLE
Fix: Correctly set up uv virtual environment in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Install uv
         run: pip install uv
 
+      - name: Configure uv
+        run: |
+          uv venv
+          echo ".venv/bin" >> $GITHUB_PATH
+
       - name: Install dependencies
         # The 'postgres' extra is required for integration tests
         run: uv pip install -e .[dev,postgres]


### PR DESCRIPTION
The CI was failing because `uv pip install` was being run without a virtual environment.

This commit fixes the issue by adding a step to:
1. Create a virtual environment using `uv venv`.
2. Add the virtual environment's `bin` directory to the `GITHUB_PATH`.

This ensures that `uv pip install` runs within a virtual environment and that subsequent steps can find the installed tools.