### PR TITLE
Fix linting errors and test configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,16 @@ def postgres_url(postgres_container: PostgresContainer) -> str:
 @pytest.fixture(scope="session")
 def test_data_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "integration")
+
+
+@pytest.fixture(scope="session")
+def db_connector(
+    postgres_container: "PostgresContainer",
+) -> "DatabaseConnectorInterface":
+    from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
+    from load_clinicaltrialsgov.connectors.interface import (
+        DatabaseConnectorInterface,
+    )
+    # The DSN is already set correctly by the postgres_container fixture
+    connector = PostgresConnector()
+    return connector

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -1,4 +1,3 @@
-import pytest
 from typer.testing import CliRunner
 from load_clinicaltrialsgov.config import settings
 import json

--- a/tests/integration/test_delta_load.py
+++ b/tests/integration/test_delta_load.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, create_autospec
-from typing import Any, cast
+from typing import cast
 import datetime
 
 from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
@@ -8,8 +8,7 @@ from load_clinicaltrialsgov.extractor.api_client import APIClient
 from load_clinicaltrialsgov.transformer.transformer import Transformer
 from load_clinicaltrialsgov.orchestrator import Orchestrator
 
-# Import fixtures from the other test file
-from .test_full_etl import db_connector # noqa: F401
+# Fixtures are automatically discovered by pytest
 
 
 # A study that was last updated before the delta load

--- a/tests/integration/test_full_etl.py
+++ b/tests/integration/test_full_etl.py
@@ -1,17 +1,8 @@
 import pytest
 import pandas as pd
+from testcontainers.postgres import PostgresContainer
 from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
 from load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
-from load_clinicaltrialsgov.config import settings
-
-
-@pytest.fixture(scope="module")
-def db_connector(
-    postgres_container: "PostgresContainer",
-) -> DatabaseConnectorInterface:
-    # The DSN is already set correctly by the postgres_container fixture
-    connector = PostgresConnector()
-    return connector
 
 
 def test_full_etl_flow(db_connector: DatabaseConnectorInterface) -> None:

--- a/tests/integration/test_full_etl_with_api.py
+++ b/tests/integration/test_full_etl_with_api.py
@@ -1,8 +1,6 @@
 import pytest
 import json
-from unittest.mock import MagicMock, patch
 from testcontainers.postgres import PostgresContainer
-import pandas as pd
 from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
 from load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
 from load_clinicaltrialsgov.config import settings

--- a/tests/integration/test_orchestrator_flow.py
+++ b/tests/integration/test_orchestrator_flow.py
@@ -8,8 +8,7 @@ from load_clinicaltrialsgov.extractor.api_client import APIClient
 from load_clinicaltrialsgov.transformer.transformer import Transformer
 from load_clinicaltrialsgov.orchestrator import Orchestrator
 
-# Import fixtures from the other test file
-from .test_full_etl import db_connector # noqa: F401
+# Fixtures are automatically discovered by pytest
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_schema_validation.py
+++ b/tests/integration/test_schema_validation.py
@@ -42,7 +42,7 @@ def test_database_schema_validation(
 
     engine = create_engine(postgres_url)
     inspector = inspect(engine)
-    with engine.connect() as connection:
+    with engine.connect() as _:
         # Check that all expected tables are created
         expected_tables = [
             "raw_studies",

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -2,13 +2,14 @@ import httpx
 import pytest
 from datetime import datetime
 from typing import List, Tuple, Any
+import tenacity
+from tenacity import stop_after_attempt
 
 
 from load_clinicaltrialsgov.extractor.api_client import APIClient
 from load_clinicaltrialsgov.config import settings
 
 from httpx import MockTransport, Response
-
 
 @pytest.fixture
 def mock_transport() -> MockTransport:
@@ -169,9 +170,6 @@ def test_fetch_page_does_not_retry_on_non_retryable_errors(
     # Crucially, assert that the request was only made once
     assert transport.call_count == 1
 
-
-import tenacity
-from tenacity import stop_after_attempt
 
 def test_fetch_page_gives_up_after_max_attempts() -> None:
     # Arrange

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 from typing import Any
+import pandas as pd
+import httpx
+from load_clinicaltrialsgov.models.api_models import Study
 
 from load_clinicaltrialsgov.cli import app
 
@@ -27,10 +30,6 @@ def mock_api_client() -> MagicMock:
 def mock_transformer() -> MagicMock:
     """Fixture for a mocked Transformer."""
     return MagicMock()
-
-
-import pandas as pd
-from load_clinicaltrialsgov.models.api_models import Study
 
 
 def test_run_command_successful_full_load(
@@ -122,9 +121,6 @@ def test_run_command_successful_delta_load(
         )
         mock_connector.record_load_history.assert_called_once()
         assert mock_connector.record_load_history.call_args[0][0] == "SUCCESS"
-
-
-import httpx
 
 
 def test_run_command_api_error(

--- a/tests/unit/test_postgres_connector.py
+++ b/tests/unit/test_postgres_connector.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import MagicMock, patch
 from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
 from load_clinicaltrialsgov.config import settings

--- a/tests/unit/test_transformer_data_quality.py
+++ b/tests/unit/test_transformer_data_quality.py
@@ -1,4 +1,3 @@
-import pytest
 from load_clinicaltrialsgov.transformer.transformer import Transformer
 from load_clinicaltrialsgov.models.api_models import Study
 

--- a/tests/unit/test_transformer_robustness.py
+++ b/tests/unit/test_transformer_robustness.py
@@ -1,4 +1,3 @@
-import pytest
 from load_clinicaltrialsgov.transformer.transformer import Transformer
 from load_clinicaltrialsgov.models.api_models import Study
 


### PR DESCRIPTION
This commit fixes a number of linting errors reported by ruff, including unused imports, redefined variables, and misplaced imports.

It also refactors the test setup by:
- Ensuring all necessary 'dev' and 'postgres' dependencies are installed for testing.
- Moving the 'db_connector' pytest fixture from a test file to the central 'tests/conftest.py' to ensure it is discoverable by all tests that need it.
- Removing now-unnecessary fixture imports from test files.