### PR TITLE
Fix ruff linting errors in tests (#65)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from load_clinicaltrialsgov.config import settings
 from alembic.config import Config
 from alembic import command
 from typing import Generator
+from load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
 
 
 @pytest.fixture(scope="session")
@@ -50,11 +51,8 @@ def test_data_dir() -> str:
 @pytest.fixture(scope="session")
 def db_connector(
     postgres_container: "PostgresContainer",
-) -> "DatabaseConnectorInterface":
+) -> DatabaseConnectorInterface:
     from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
-    from load_clinicaltrialsgov.connectors.interface import (
-        DatabaseConnectorInterface,
-    )
     # The DSN is already set correctly by the postgres_container fixture
     connector = PostgresConnector()
     return connector

--- a/tests/integration/test_full_etl.py
+++ b/tests/integration/test_full_etl.py
@@ -1,6 +1,4 @@
-import pytest
 import pandas as pd
-from testcontainers.postgres import PostgresContainer
 from load_clinicaltrialsgov.connectors.postgres import PostgresConnector
 from load_clinicaltrialsgov.connectors.interface import DatabaseConnectorInterface
 


### PR DESCRIPTION
This commit fixes a few linting errors reported by ruff in the test suite.

- In `tests/conftest.py`, `DatabaseConnectorInterface` was used as a type hint before it was defined, causing an `F821 Undefined name` error. This was fixed by moving the import to the top of the file.
- In `tests/integration/test_full_etl.py`, `pytest` and `testcontainers.postgres.PostgresContainer` were imported but not used, causing `F401 unused import` errors. These unused imports have been removed.