### PR TITLE
Fix: resolve E402 linting error in test_cli_e2e.py (#71)

### DIFF
--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -1,13 +1,11 @@
 from typer.testing import CliRunner
+from pytest import MonkeyPatch
 from load_clinicaltrialsgov.config import settings
 import json
 from unittest.mock import patch, MagicMock
 import psycopg
 
 runner = CliRunner()
-
-
-from pytest import MonkeyPatch
 
 
 def test_cli_run_e2e(postgres_url: str, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
Moved the `from pytest import MonkeyPatch` import to the top of the file to resolve the `E402 Module level import not at top of file` linting error.