### PR TITLE
fix: resolve linter errors causing CI failures

### DIFF
--- a/src/load_clinicaltrialsgov/transformer/transformer.py
+++ b/src/load_clinicaltrialsgov/transformer/transformer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import json
 import structlog
-from typing import Dict, List, Any, cast
+from typing import Dict, List, Any
 from load_clinicaltrialsgov.models.api_models import Study
 from datetime import datetime, UTC
 from dateutil.parser import parse as date_parse, ParserError

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -124,9 +124,6 @@ def test_fetch_page_retries_on_retryable_errors(retryable_status_code: int) -> N
     assert transport.call_count == 2
 
 
-from unittest.mock import MagicMock
-
-
 def test_api_call_retries_on_500() -> None:
     # Arrange
     responses: List[Tuple[int, dict[str, Any]] | Exception] = [


### PR DESCRIPTION
This commit fixes two types of linter errors that were causing the CI pipeline to fail:

- Removed an unused import of `typing.cast` in `src/load_clinicaltrialsgov/transformer/transformer.py`.
- Removed an unused import of `unittest.mock.MagicMock` in `tests/unit/test_api_client.py` and fixed the import order.