### PR TITLE
Fix: Update Pydantic models to match API response

### DIFF
--- a/src/load_clinicaltrialsgov/models/api_models.py
+++ b/src/load_clinicaltrialsgov/models/api_models.py
@@ -44,6 +44,7 @@ class OutcomesModule(BaseModel):
 
 class DescriptionModule(BaseModel):
     brief_summary: Optional[str] = Field(None, alias="briefSummary")
+    detailed_description: Optional[str] = Field(None, alias="detailedDescription")
 
 
 class ConditionsModule(BaseModel):
@@ -74,6 +75,7 @@ class StatusModule(BaseModel):
 
 class DesignModule(BaseModel):
     study_type: Optional[str] = Field(None, alias="studyType")
+    phases: Optional[List[str]] = None
 
 
 class ProtocolSection(BaseModel):


### PR DESCRIPTION
The CI pipeline was failing with a Pydantic `ValidationError` because the API was returning fields that were not defined in the Pydantic models.

This commit updates the `DescriptionModule` and `DesignModule` models to include the `detailedDescription` and `phases` fields, respectively. This allows the models to correctly parse the API response and resolves the validation error.