### PR TITLE
Fix: Correct formatting to resolve CI failures

### DIFF
--- a/src/load_clinicaltrialsgov/config.py
+++ b/src/load_clinicaltrialsgov/config.py
@@ -4,7 +4,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class APISettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="API_")
-    base_url: str = Field("https://clinicaltrials.gov/api/v2", description="base url for the api")
+    base_url: str = Field(
+        "https://clinicaltrials.gov/api/v2", description="base url for the api"
+    )
     timeout: int = Field(30, description="Timeout for API requests in seconds.")
     max_retries: int = Field(
         5, description="Maximum number of retries for failed API requests."


### PR DESCRIPTION
The CI pipeline was failing due to a code formatting issue. This change runs the `ruff` formatter to correct the code style and ensure that the CI pipeline can run successfully.

All tests have been run locally and are passing.